### PR TITLE
Feature/daiki kazusaki/remove valid move

### DIFF
--- a/Main/main.py
+++ b/Main/main.py
@@ -32,7 +32,7 @@ while not done:
     valid_action = False
     while not valid_action:
         action, _ = model.predict(obs)  # モデルからアクションを予測
-        if action_counts[action] < 3:   # アクションが3回未満なら有効
+        if action_counts[action] <= 4:   # アクションが4回以下なら有効
             valid_action = True
             action_counts[action] += 1  # アクションのカウントを更新
         else:

--- a/Main/main.py
+++ b/Main/main.py
@@ -53,12 +53,3 @@ while not done:
 print("Final reward:", reward)
 
 renderer.render(move_list, interval=1000)
-
-# 3回以上同じ手を打たないようにする
-def is_able_to_put(action):
-    is_able_to_put[action] += 1
-
-    if is_able_to_put[action] > 3:
-        return False
-    
-    return True

--- a/Main/main.py
+++ b/Main/main.py
@@ -5,6 +5,7 @@ from stable_baselines3 import PPO
 import gymnasium as gym
 from Opponent.StrongOpponent import StrongOpponent
 
+is_able_to_put = [0] * 16
 
 # ランダムな相手プレイヤーのインスタンスを作成
 # opponent_instance = RandomOpponent()
@@ -21,14 +22,14 @@ model.learn(total_timesteps=300000)  # 任意
 # 学習後にテスト
 obs, info = env.reset()
 done = False
-tmp=obs.copy()
+tmp = obs.copy()
 # env.set_opponent(ModelOpponent(model2, Environment()))
 move_list=[] #ここに履歴を保存
 while not done:
     action, _ = model.predict(obs)
     obs, reward, done, truncated, info = env.step(action)
-    changed_indices=np.where(tmp != obs) #1step前との差分を取得
-    change_list=[]
+    changed_indices = np.where(tmp != obs) #1step前との差分を取得
+    change_list = []
     for idx in zip(*changed_indices):#差分すべてをチェック
         x, y, z = idx #x,y,z座標を取得
         value = obs[idx] #ぞの座標におかれたのがどちらの石かを取得
@@ -36,8 +37,16 @@ while not done:
             change_list.insert(0, [x, y]) 
         elif value == -1:#白が後手なので後に格納
             change_list.append([x, y]) 
-        tmp[idx]=value #ひとつ前の盤面を更新
-    move_list+=change_list #move_listに結合
+        tmp[idx] = value #ひとつ前の盤面を更新
+    move_list += change_list #move_listに結合
 print("Final reward:", reward)
 
 renderer.render(move_list, interval=1000)
+
+def is_able_to_put(action):
+    is_able_to_put[action] += 1
+    
+    if is_able_to_put[action] > 3:
+        return False
+    
+    return True

--- a/Main/main.py
+++ b/Main/main.py
@@ -5,7 +5,7 @@ from stable_baselines3 import PPO
 import gymnasium as gym
 from Opponent.StrongOpponent import StrongOpponent
 
-is_able_to_put = [0] * 16
+action_counts = [0] * 16
 
 # ランダムな相手プレイヤーのインスタンスを作成
 # opponent_instance = RandomOpponent()
@@ -28,9 +28,15 @@ move_list=[] #ここに履歴を保存
 while not done:
     action, _ = model.predict(obs)
 
-    # actionが置ける場所でない場合はランダムに選び直す
-    while not is_able_to_put(action):
-        action, _ = model.predict(obs)
+    # アクションを取得してリトライが必要か確認
+    valid_action = False
+    while not valid_action:
+        action, _ = model.predict(obs)  # モデルからアクションを予測
+        if action_counts[action] < 3:   # アクションが3回未満なら有効
+            valid_action = True
+            action_counts[action] += 1  # アクションのカウントを更新
+        else:
+            print(f"Action {action} has been selected 3 times. Retrying...")
     
     obs, reward, done, truncated, info = env.step(action)
     changed_indices = np.where(tmp != obs) #1step前との差分を取得

--- a/Main/main.py
+++ b/Main/main.py
@@ -27,6 +27,11 @@ tmp = obs.copy()
 move_list=[] #ここに履歴を保存
 while not done:
     action, _ = model.predict(obs)
+
+    # actionが置ける場所でない場合はランダムに選び直す
+    while not is_able_to_put(action):
+        action, _ = model.predict(obs)
+    
     obs, reward, done, truncated, info = env.step(action)
     changed_indices = np.where(tmp != obs) #1step前との差分を取得
     change_list = []
@@ -43,9 +48,10 @@ print("Final reward:", reward)
 
 renderer.render(move_list, interval=1000)
 
+# 3回以上同じ手を打たないようにする
 def is_able_to_put(action):
     is_able_to_put[action] += 1
-    
+
     if is_able_to_put[action] > 3:
         return False
     


### PR DESCRIPTION
`PPO.predict`が不要な値を返さないようにする方法についてのChatGPTの解答がこちら．
```
PPOモデル (stable-baselines3) の predict メソッドは学習された方策に従って次のアクションを予測する仕組みを持っています。しかし、そのままでは同じアクションを5回以上選択しないようにするロジックはありません。そのため、predict メソッド自体をカスタマイズするか、方策関数に制約を導入する必要があります。
```
なさそうだったので，`while`文を用いて`PPO.predict()`の返り値が有効かを判定するようにしました．
- `action_counts`リストを用意して，`action, _ = PPO.predict()`の`action`の登場した回数を記録
- `action`の値の登場回数が4回以下なら`while`文を`break`
- `action`の値の登場回数が5回以上ならもう一度`action, _ = PPO.predict()`を実行